### PR TITLE
Update to RocksDB v6.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ but otherwise strives to be as close as possible to the upstream code.
 It also changes how `librocksdb-sys` is built to work around a very stupid assumption bug in the RocksDB code that
 causes log output to be corrupted.
 
+# Procedure to update:
+
+* Update the linked RocksDB version.  See the `librocksdb-sys/README.md` file for instructions
+* Merge the update into the `assurio` branch (we reserve `master` to sync changes from upstream)
+* Create a tag on the repo with the version of Rocks it corresponds to.  Eg `tags/v6.6.4` for the version that uses
+    RocksDB 6.6.4.
+
+Note that, somewhat counterintuitively, the version of the `rust-rocksdb` crate doesn't reflect the RocksDB version.
+Rather, the version of the `librocksdb-sys` does.  Rather than fight that convention, we leave it in place for now.
+Downstream crates incorporate this one via Git submodules using the tag created above.  It's not idea but it works for
+now.
+
 rust-rocksdb
 ============
 [![Build Status](https://travis-ci.org/rust-rocksdb/rust-rocksdb.svg?branch=master)](https://travis-ci.org/rust-rocksdb/rust-rocksdb)

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "librocksdb-sys"
-version = "6.5.2"
+version = "6.6.4"
 authors = ["Karl Hobley <karlhobley10@gmail.com>", "Arkadiy Paronyan <arkadiy@ethcore.io>"]
 license = "MIT/Apache-2.0/BSD-3-Clause"
 description = "Native bindings to librocksdb (unofficial assurio fork)"

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -187,6 +187,9 @@ fn build_rocksdb() {
         config.flag("-Wno-unused-parameter");
     }
 
+    // All platforms supported here also support thread-local storage
+    config.define("ROCKSDB_SUPPORT_THREAD_LOCAL", Some("1"));
+
     //Build a single `.cc` file in the out dir which will `#include` every source file in the
     //library.  This sucks compared to just calling `config.file` once for each source file so we
     //can take advantage of the inherenet parallelism of C++ compilation, but that doesn't work.

--- a/librocksdb-sys/build_version.cc
+++ b/librocksdb-sys/build_version.cc
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 #include "build_version.h"
-const char* rocksdb_build_git_sha = "rocksdb_build_git_sha:4cfbd87afd08a16df28436fb990ef6b154ee6114";
-const char* rocksdb_build_git_date = "rocksdb_build_git_date:2020-01-06";
+const char* rocksdb_build_git_sha = "rocksdb_build_git_sha:551a110918493a19d11243f53408b97485de1411";
+const char* rocksdb_build_git_date = "rocksdb_build_git_date:2020-02-10";
 const char* rocksdb_build_compile_date = __DATE__;

--- a/librocksdb-sys/rocksdb_lib_sources.txt
+++ b/librocksdb-sys/rocksdb_lib_sources.txt
@@ -1,6 +1,7 @@
 cache/clock_cache.cc
 cache/lru_cache.cc
 cache/sharded_cache.cc
+db/arena_wrapped_db_iter.cc
 db/builder.cc
 db/c.cc
 db/column_family.cc
@@ -68,9 +69,15 @@ env/env_posix.cc
 env/io_posix.cc
 env/mock_env.cc
 file/delete_scheduler.cc
+file/file_prefetch_buffer.cc
 file/file_util.cc
 file/filename.cc
+file/random_access_file_reader.cc
+file/read_write_util.cc
+file/readahead_raf.cc
+file/sequence_file_reader.cc
 file/sst_file_manager_impl.cc
+file/writable_file_writer.cc
 logging/auto_roll_logger.cc
 logging/event_logger.cc
 logging/log_buffer.cc
@@ -116,9 +123,11 @@ table/block_based/block_prefix_index.cc
 table/block_based/data_block_hash_index.cc
 table/block_based/data_block_footer.cc
 table/block_based/filter_block_reader_common.cc
+table/block_based/filter_policy.cc
 table/block_based/flush_block_policy.cc
 table/block_based/full_filter_block.cc
 table/block_based/index_builder.cc
+table/block_based/parsed_full_filter_block.cc
 table/block_based/partitioned_filter_block.cc
 table/block_based/uncompression_dict_reader.cc
 table/block_fetcher.cc
@@ -147,7 +156,6 @@ test_util/transaction_test_util.cc
 tools/dump/db_dump_tool.cc
 trace_replay/trace_replay.cc
 trace_replay/block_cache_tracer.cc
-util/bloom.cc
 util/build_version.cc
 util/coding.cc
 util/compaction_job_stats_impl.cc
@@ -156,8 +164,6 @@ util/compression_context_cache.cc
 util/concurrent_task_limiter_impl.cc
 util/crc32c.cc
 util/dynamic_bloom.cc
-util/file_reader_writer.cc
-util/filter_policy.cc
 util/hash.cc
 util/murmurhash.cc
 util/random.cc


### PR DESCRIPTION
This isn't just a routine update.  This enables `format_version=5`, a
new on-disk format that uses a vastly improved Bloom filter for much
better query performance.

It also uses a new 64-bit optimized hash algorithm for non-persistent
hash use cases, which uses AVX2 instructions (meaning it requires a
Haswell or later processor, circa 2014).

This is a required pre-req for https://github.com/assuriosw/assurio/issues/37.
