### PR TITLE
Update bindgen and uuid in dependencies of librocksdb-sys

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -85,7 +85,7 @@ def rust_step(name, target, commands):
 
     return step
 
-def rust_build_step(target, toolchain = "1.32"):
+def rust_build_step(target, toolchain = "1.42"):
     commands = [
         #"dir C:\\ProgramData\\scoop\\apps\\rustup-msvc\\current\\.cargo\\bin",
         #"\"C:\\ProgramData\\scoop\\apps\\rustup-msvc\\current\\.cargo\\bin\\cargo.exe version\"",

--- a/.drone.star
+++ b/.drone.star
@@ -85,11 +85,11 @@ def rust_step(name, target, commands):
 
     return step
 
-def rust_build_step(target, toolchain = "stable"):
+def rust_build_step(target, toolchain = "1.32"):
     commands = [
         #"dir C:\\ProgramData\\scoop\\apps\\rustup-msvc\\current\\.cargo\\bin",
         #"\"C:\\ProgramData\\scoop\\apps\\rustup-msvc\\current\\.cargo\\bin\\cargo.exe version\"",
-        #"\"C:\\ProgramData\\scoop\\apps\\rustup-msvc\\current\\.cargo\\bin\\cargo.exe +stable version\"",
+        #"\"C:\\ProgramData\\scoop\\apps\\rustup-msvc\\current\\.cargo\\bin\\cargo.exe +1.42 version\"",
         #"\"C:\\ProgramData\\scoop\\apps\\rustup-msvc\\current\\.cargo\\bin\\cargo.exe +{tc} version\"".format(tc = toolchain),
         "cargo version",
         "rustup show",

--- a/.drone.star
+++ b/.drone.star
@@ -85,11 +85,11 @@ def rust_step(name, target, commands):
 
     return step
 
-def rust_build_step(target, toolchain = "1.42"):
+def rust_build_step(target, toolchain = "1.42.0"):
     commands = [
         #"dir C:\\ProgramData\\scoop\\apps\\rustup-msvc\\current\\.cargo\\bin",
         #"\"C:\\ProgramData\\scoop\\apps\\rustup-msvc\\current\\.cargo\\bin\\cargo.exe version\"",
-        #"\"C:\\ProgramData\\scoop\\apps\\rustup-msvc\\current\\.cargo\\bin\\cargo.exe +1.42 version\"",
+        #"\"C:\\ProgramData\\scoop\\apps\\rustup-msvc\\current\\.cargo\\bin\\cargo.exe +1.42.0 version\"",
         #"\"C:\\ProgramData\\scoop\\apps\\rustup-msvc\\current\\.cargo\\bin\\cargo.exe +{tc} version\"".format(tc = toolchain),
         "cargo version",
         "rustup show",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rocksdb"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["Tyler Neely <t@jujit.su>", "David Greenberg <dsg123456789@gmail.com>"]
 license = "Apache-2.0"
 keywords = ["database", "embedded", "LSM-tree", "persistence"]

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -26,10 +26,10 @@ libc = "0.2"
 
 [dev-dependencies]
 const-cstr = "0.3"
-uuid = { version = "0.7", features = ["v4"] }
+uuid = { version = "0.8", features = ["v4"] }
 
 [build-dependencies]
 cc = { version = "^1.0", features = ["parallel"] }
-bindgen = "0.49"
+bindgen = "0.53"
 glob = "0.3"
 dunce = "1"

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -46,6 +46,7 @@ fn bindgen_rocksdb() {
         .header("rocksdb/include/rocksdb/c.h")
         .blacklist_type("max_align_t") // https://github.com/rust-lang-nursery/rust-bindgen/issues/550
         .ctypes_prefix("libc")
+        .size_t_is_usize(true)
         .generate()
         .expect("unable to generate rocksdb bindings");
 


### PR DESCRIPTION
Summary:
Crate librocksdb-sys and crates in assurio repository use different versions of
bindgen and uuid. We should update them to the latest versions for avoiding
duplicates of dependencies.

Changes:
 - Update bindgen to 0.53
 - Update uuid to 0.8
 - Consider size_t in new version of FFI as usize in Rust code.
 - Increment rust-rocksdb version to 0.12.4