### PR TITLE
Enable thread local storage on all targets

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -135,6 +135,9 @@ fn build_rocksdb() {
         }
     }
 
+    // All targets support thread-local storage
+    config.define("ROCKSDB_SUPPORT_THREAD_LOCAL", Some("1"));
+
     if target.contains("darwin") {
         config.define("OS_MACOSX", Some("1"));
         config.define("ROCKSDB_PLATFORM_POSIX", Some("1"));


### PR DESCRIPTION
This is a subtle but important omission.  Rocks uses thread-local storage for per-thread performance stats, which we make use of.  Without thread local storage enabled, these stats are stored globally.  That causes rare test failures, and obviously also means the performance stats are not thread local at all but global.
